### PR TITLE
Use disabled attribute to disable embedded paper-sliders

### DIFF
--- a/paper-range-slider.html
+++ b/paper-range-slider.html
@@ -917,8 +917,8 @@ See README.md for further details.
             this.disabled = isDisabled;
             var pointEvt  = isDisabled ? "none" : "auto";
 
-            this.$$("#sliderMax").$$('#sliderKnobInner').style.pointerEvents            = pointEvt;
-            this.$$("#sliderMin").$$('#sliderKnobInner').style.pointerEvents            = pointEvt;
+            this.$$("#sliderMax").disabled = isDisabled;
+            this.$$("#sliderMin").disabled = isDisabled;
             this.$$("#sliderOuterDiv_1").style.pointerEvents                            = pointEvt;
             this.$$("#sliderKnobMin").style.pointerEvents                               = pointEvt;
             this.$$("#sliderKnobMax").style.pointerEvents                               = pointEvt;


### PR DESCRIPTION
This fixes compatibility with both paper-slider 1.0.11 and 1.0.12 and prevents us from going into shadow DOM from embedded web components.

Fixes #8 
