### PR TITLE
Change type of style property to object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## paper-range-slider 0.2.8 (26/10/2017)
+
+- Change type of style property to object.
+
 ## paper-range-slider 0.2.7 (19/04/2017)
 
 - Fixed cursor style for `single-slider` option.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-range-slider",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "authors": [
     "Iftach Sadeh <iftach.sadeh@desy.de>"
   ],

--- a/paper-range-slider.html
+++ b/paper-range-slider.html
@@ -172,8 +172,8 @@ See README.md for further details.
              * the style attribute of the element.
              */
             style: {
-                type: String,
-                value: "",
+                type: Object,
+                value: function() {return {}},
                 notify: true,
                 reflectToAttribute: true
             },


### PR DESCRIPTION
Hi Iftach,

We started using your component, which works great! Thanks for having created it.

We've run into a problem in our application when we bundled it with vulcanizer. (It works if not being vulcanised). It's complicated to create a test case to reproduce, but the fix is easy.

We use version 0.2.7 because we are still with Polymer 1.x. The problem comes from the 'style' property, which is declared as of type String, but in reality is used as an object. So it crashes in _setPadding, when doing 
```this.style.paddingTop  = height+"px".```

The error message in the console : 
```
rz-app-7ed4e2768e.js:11 Uncaught TypeError: Cannot create property 'paddingTop' on string ''
    at HTMLElement._setPadding (rz-app-7ed4e2768e.js:11)
    at HTMLElement._renderedReady (rz-app-7ed4e2768e.js:11)
    at HTMLElement.ready (rz-app-7ed4e2768e.js:11)
    at HTMLElement._readySelf (rz-app-7ed4e2768e.js:1)
    at HTMLElement._ready (rz-app-7ed4e2768e.js:1)
    at HTMLElement._readyClients (rz-app-7ed4e2768e.js:1)
    at HTMLElement._ready (rz-app-7ed4e2768e.js:1)
    at HTMLElement._readyClients (rz-app-7ed4e2768e.js:1)
    at HTMLElement._ready (rz-app-7ed4e2768e.js:1)
    at n._readyClients (rz-app-7ed4e2768e.js:1)
```

We just changed the type to an object and it works. 

I've created a new branch for a Polymer 1.x version. Would you mind creating it as well? It would help us to maintain it before migrating to Polymer 2.x. 

By the way, you can easily backport this fix in master by changing the type of mainDivStyle.

