### PR TITLE
Fix custom CSS variables

### DIFF
--- a/paper-range-slider.html
+++ b/paper-range-slider.html
@@ -1142,6 +1142,7 @@ See README.md for further details.
 
         -webkit-transform: rotate(-45deg) scale(0) translate(0);
         transform: rotate(-45deg) scale(0) translate(0);
+        @apply --paper-single-range-slider-knob-inner;
       }
 
       .slider-knob-inner::before,
@@ -1173,7 +1174,7 @@ See README.md for further details.
 
         -webkit-transform: scale(0) translate(0);
         transform: scale(0) translate(0);
-        @apply paper-single-range-slider-knob-inner-text;
+        @apply --paper-single-range-slider-knob-inner-text;
       }
 
       .pin.expand > .slider-knob > .slider-knob-inner::after {


### PR DESCRIPTION
This PR adds the missing two hyphen to the `paper-single-range-slider-knob-inner-text` CSS variable and adds `paper-single-range-slider-knob-inner` as a CSS variable to alter the styling of the `::before` element.