### PR TITLE
Allows `paper-single-range-slider` to always show pin

### DIFF
--- a/paper-range-slider.html
+++ b/paper-range-slider.html
@@ -1461,7 +1461,9 @@ See README.md for further details.
 
       _resetKnob: function() {
         this.cancelDebouncer('expandKnob');
-        this._setExpand(false);
+        if(!this.expand) {
+          this._setExpand(false);
+        }
       },
 
       _setExpand(val) {

--- a/paper-range-slider.html
+++ b/paper-range-slider.html
@@ -1464,6 +1464,10 @@ See README.md for further details.
         this._setExpand(false);
       },
 
+      _setExpand(val) {
+        this.expand = val;
+      },
+
       _positionKnob: function(ratio) {
         this._setImmediateValue(this._calcStep(this._calcKnobPosition(ratio)));
         this._setRatio(this._calcRatio(this.immediateValue) * 100);

--- a/paper-range-slider.html
+++ b/paper-range-slider.html
@@ -1364,8 +1364,7 @@ See README.md for further details.
          */
         expand: {
           type: Boolean,
-          value: false,
-          readOnly: true
+          value: false
         },
 
         /**


### PR DESCRIPTION
fixes a few things, 

1. There's no `_setExpand` method in `paper-single-range-slider`
2. Removes `readonly` mode on `expand`, this allows us to set expand mode on the element to always show the knob/pin
3. resets a knob only if expand is not true

Thanks!