### PR TITLE
fixes an issue where the pin is not shown when the element is first added to the DOM

### DIFF
--- a/paper-range-slider.html
+++ b/paper-range-slider.html
@@ -1364,7 +1364,8 @@ See README.md for further details.
          */
         expand: {
           type: Boolean,
-          value: false
+          value: false,
+          observer: "_expandChanged"
         },
 
         /**
@@ -1412,6 +1413,7 @@ See README.md for further details.
 
       ready: function() {
         this.isReady = true;
+        this._enableKnob();
         return;
       },
 
@@ -1453,6 +1455,14 @@ See README.md for further details.
 
       _secondaryProgressChanged: function() {
         this.secondaryProgress = this._clampValue(this.secondaryProgress);
+      },
+
+      _expandChanged(newVal, oldVal) {
+        this._enableKnob(newVal);
+      },
+
+      _enableKnob: function() {
+        this._setExpand(this.expand);
       },
 
       _expandKnob: function() {


### PR DESCRIPTION
1. at ready, enables the knob and the pin based on the `expand` attribute
2. add observer to reflect ui when `expand` attribute changes.

Thanks!